### PR TITLE
Handle missing song lists and report batch download failures

### DIFF
--- a/PlayniteSounds.cs
+++ b/PlayniteSounds.cs
@@ -2041,7 +2041,11 @@ namespace PlayniteSounds
                 var message = $"Failed to download music for {failedGames.Count} item(s). Check logs for details.";
                 if (_muteExceptions)
                 {
-                    _mutedErrors = new List<string> { message };
+                    if (_mutedErrors == null)
+                    {
+                        _mutedErrors = new List<string>();
+                    }
+                    _mutedErrors.Add(message);
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- Safeguard YouTube download workflow by fetching songs for an album before picking the best match
- Continue processing games after errors and show a summary of failed downloads

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_689b807956788322b4cda81303ec3475