### PR TITLE
Add audio cue when game installation starts

### DIFF
--- a/Common/Constants/SoundFile.cs
+++ b/Common/Constants/SoundFile.cs
@@ -13,6 +13,7 @@ namespace PlayniteSounds.Common.Constants
 
         public static string ApplicationStartedSound => CurrentPrefix + BaseApplicationStartedSound;
         public static string ApplicationStoppedSound => CurrentPrefix + BaseApplicationStoppedSound;
+        public static string GameInstallSound => CurrentPrefix + BaseGameInstallSound;
         public static string GameInstalledSound => CurrentPrefix + BaseGameInstalledSound;
         public static string GameSelectedSound => CurrentPrefix + BaseGameSelectedSound;
         public static string GameStartedSound => CurrentPrefix + BaseGameStartedSound;
@@ -28,6 +29,7 @@ namespace PlayniteSounds.Common.Constants
 
         public const string BaseApplicationStartedSound = "ApplicationStarted.wav";
         public const string BaseApplicationStoppedSound = "ApplicationStopped.wav";
+        public const string BaseGameInstallSound = "GameInstall.wav";
         public const string BaseGameInstalledSound = "GameInstalled.wav";
         public const string BaseGameSelectedSound = "GameSelected.wav";
         public const string BaseGameStartedSound = "GameStarted.wav";

--- a/PlayniteSounds.cs
+++ b/PlayniteSounds.cs
@@ -58,6 +58,7 @@ namespace PlayniteSounds
                     Resource.MsgHelp6 + "\n\n" +
                     HelpLine(SoundFile.BaseApplicationStartedSound) +
                     HelpLine(SoundFile.BaseApplicationStoppedSound) +
+                    HelpLine(SoundFile.BaseGameInstallSound) +
                     HelpLine(SoundFile.BaseGameInstalledSound) +
                     HelpLine(SoundFile.BaseGameSelectedSound) +
                     HelpLine(SoundFile.BaseGameStartedSound) +
@@ -173,6 +174,7 @@ namespace PlayniteSounds
                 DownloadManager = new DownloadManager(Settings, Path.Combine(_musicFilesDataPath,"tmp"));
 
                 PlayniteApi.Database.Games.ItemCollectionChanged += CleanupDeletedGames;
+                PlayniteApi.Database.Games.ItemUpdated += OnGameItemUpdated;
                 PlayniteApi.Database.Platforms.ItemCollectionChanged += UpdatePlatforms;
                 PlayniteApi.Database.FilterPresets.ItemCollectionChanged += UpdateFilters;
                 PlayniteApi.UriHandler.RegisterSource("Sounds", HandleUriEvent);
@@ -541,6 +543,18 @@ namespace PlayniteSounds
             }
 
             DeleteDirectories(ItemCollectionChangedArgs.RemovedItems, GetFilterDirectoryPath);
+        }
+
+        private void OnGameItemUpdated(object sender, ItemUpdatedEventArgs<Game> args)
+        {
+            foreach (var update in args.UpdatedItems)
+            {
+                if (update.OldData != null && update.NewData != null &&
+                    !update.OldData.IsInstalling && update.NewData.IsInstalling)
+                {
+                    PlaySoundFileFromName(SoundFile.GameInstallSound);
+                }
+            }
         }
 
         private void DeleteDirectories<T>(IEnumerable<T> directoryLinks, Func<T, string> PathConstructor)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ They are located in the sounds folder of the extension, you can open that folder
 | ------------- |---------------|-------|
 | Playnite Startup | D_ApplicationStarted.wav | F_ApplicationStarted.wav |
 | Playnite Exit     | D_ApplicationStopped.wav | F_ApplicationStopped.wav |
+| Game Installing | D_GameInstall.wav | F_GameInstall.wav |
 | Game Installed | D_GameInstalled.wav | F_GameInstalled.wav |
 | Game UnInstalled | D_GameUninstalled.wav | F_GameUninstalled.wav |
 | Game Selected | D_GameSelected.wav |  F_GameSelected.wav |


### PR DESCRIPTION
## Summary
- Add `GameInstall` sound constant and base filename
- Play sound when a game's installation begins by monitoring `IsInstalling`
- Document new `GameInstall` sound files in README

## Testing
- `xbuild PlayniteSounds.sln` *(fails: default XML namespace must be MSBuild)*

------
https://chatgpt.com/codex/tasks/task_e_689b812c59c083229990def11ed59165